### PR TITLE
Scalajs rework hints

### DIFF
--- a/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSModule.scala
@@ -9,8 +9,8 @@ import mill.scalalib.{DepSyntax, Lib, TestModule}
 import mill.testrunner.TestRunner
 import mill.define.{Command, Target, Task}
 import mill.scalajslib.{ScalaJSWorker => DeprecatedScalaJSWorker}
-import mill.scalajslib.api._
-import mill.scalajslib.worker._
+import mill.scalajslib.api.{ESFeatures, ESVersion, FullOpt, JsEnvConfig, ModuleKind, OptimizeMode, Report}
+import mill.scalajslib.worker.{ScalaJSWorker, ScalaJSWorkerExternalModule}
 
 import scala.jdk.CollectionConverters._
 
@@ -140,7 +140,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
       moduleKind: ModuleKind,
       esFeatures: ESFeatures
   )(implicit ctx: mill.api.Ctx): Result[PathRef] = linkJs(
-    worker = worker.newWorker,
+    worker = worker.bridgeWorker,
     toolsClasspath = toolsClasspath,
     runClasspath = runClasspath,
     mainClass = mainClass,
@@ -255,6 +255,7 @@ trait ScalaJSModule extends scalalib.ScalaModule { outer =>
 }
 
 trait TestScalaJSModule extends ScalaJSModule with TestModule {
+
   def scalaJSTestDeps = T {
     resolveDeps(T.task {
       val bridgeOrInterface =

--- a/scalajslib/src/mill/scalajslib/ScalaJSWorkerApi.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSWorkerApi.scala
@@ -8,7 +8,16 @@ import mill.scalajslib.worker.ScalaJSWorkerExternalModule
 import mill.{Agg, T}
 
 @deprecated("Use mill.scalajslib.worker.ScalaJSWorker instead", since = "mill 0.10.4")
-class ScalaJSWorker(private[scalajslib] val bridgeWorker: worker.ScalaJSWorker) extends AutoCloseable {
+class ScalaJSWorker(initialBridgeWorker: Option[worker.ScalaJSWorker]) extends AutoCloseable {
+
+  def this() = this(None)
+
+  protected[scalajslib] def bridgeWorker: worker.ScalaJSWorker = initialBridgeWorker.getOrElse(
+    throw new IllegalStateException(
+      "If you still use the deprecated mill.scalajslib.ScalaJSWorker, you need to make sure to initialize it correctly." +
+        " Please override bridgeWorker to fix this."
+    )
+  )
 
   def link(
       toolsClasspath: Agg[os.Path],
@@ -70,9 +79,11 @@ class ScalaJSWorker(private[scalajslib] val bridgeWorker: worker.ScalaJSWorker) 
 object ScalaJSWorkerApi extends mill.define.ExternalModule {
 
   def scalaJSWorker = T.worker {
-    T.log.error("mill.scalajslib.ScalaJSWorkerApi is deprecated, use mill.scalajslib.worker.ScalaJSWorkerExternalModule instead")
+    T.log.error(
+      "mill.scalajslib.ScalaJSWorkerApi is deprecated, use mill.scalajslib.worker.ScalaJSWorkerExternalModule instead"
+    )
     // delegate to the successor implementation, it's a singleton
-    new ScalaJSWorker(ScalaJSWorkerExternalModule.scalaJSWorker())
+    new ScalaJSWorker(Some(ScalaJSWorkerExternalModule.scalaJSWorker()))
   }
   lazy val millDiscover = Discover[this.type]
 }

--- a/scalajslib/src/mill/scalajslib/ScalaJSWorkerApi.scala
+++ b/scalajslib/src/mill/scalajslib/ScalaJSWorkerApi.scala
@@ -8,7 +8,7 @@ import mill.scalajslib.worker.ScalaJSWorkerExternalModule
 import mill.{Agg, T}
 
 @deprecated("Use mill.scalajslib.worker.ScalaJSWorker instead", since = "mill 0.10.4")
-class ScalaJSWorker(bridgeWorker: worker.ScalaJSWorker) extends AutoCloseable {
+class ScalaJSWorker(private[scalajslib] val bridgeWorker: worker.ScalaJSWorker) extends AutoCloseable {
 
   def link(
       toolsClasspath: Agg[os.Path],


### PR DESCRIPTION
As part of reviewing 

* https://github.com/com-lihaoyi/mill/pull/1851

I decided to put my idea into a PR to your branch.

It started with the variable name `newWorker` (https://github.com/com-lihaoyi/mill/pull/1851#discussion_r862439336).

I think, we should not create a new worker in the deprecated compatibility API. Instead, we should delegate to the newer worker. It's supposed to be a singleton and is already managed, so there is no need to create a new instance or to do anything when closing.